### PR TITLE
update Python implementation to match JS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "otel-aws-langchain-instrumentation-v2"
+name = "opentelemetry-instrumentation-langchain-v2"
 version = "0.1.0"
 description = "LangChain/LangGraph instrumentation library for OpenTelemetry"
 authors = [{name = "Eric", email = "ehrican@amazon.com"}, {name = "Michael", email = "yiyuanh@amazon.com"}, {name = "Eric", email = "zhaez@amazon.com"}]

--- a/src/opentelemetry/instrumentation/langchain_v2/__init__.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/__init__.py
@@ -3,12 +3,9 @@ from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from wrapt import wrap_function_wrapper
 
 from opentelemetry.trace import get_tracer
-
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
 
-from opentelemetry.instrumentation.langchain.version import __version__
-
+from opentelemetry.instrumentation.langchain_v2.version import __version__
 from opentelemetry.instrumentation.langchain_v2.callback_handler import OpenTelemetryCallbackHandler
 
 

--- a/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
@@ -156,6 +156,8 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> str:
         """Get the name to be used for the span. Based on heuristic. Can be extended."""
+        if "invocation_params" in kwargs and "model_id" in kwargs["invocation_params"]:
+            return  kwargs["invocation_params"]["model_id"]
         if serialized and "kwargs" in serialized and serialized["kwargs"].get("name"):
             return serialized["kwargs"]["name"]
         if kwargs.get("name"):
@@ -164,8 +166,6 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             return serialized["name"]
         if "id" in serialized:
             return serialized["id"][-1]
-        if "invocation_params" in kwargs and "model_id" in kwargs["invocation_params"]:
-            return  kwargs["invocation_params"]["model_id"]
 
         return "unknown"
 
@@ -201,8 +201,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
 
-        name = self._get_name_from_callback(serialized, kwargs=kwargs)
-
+        name = self._get_name_from_callback(serialized, **kwargs)
         span = self._create_span(
             run_id,
             parent_run_id,

--- a/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
@@ -423,7 +423,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             name
         )
 
-        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, "execute_tool")
+        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.EXECUTE_TOOL)
 
 
     def on_tool_end(self,

--- a/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
@@ -19,7 +19,7 @@ from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 
 from langchain_core.agents import AgentAction, AgentFinish
 
-from opentelemetry.instrumentation.langchain_v2.span_attributes import Span_Attributes, GenAIOperationValues
+from opentelemetry.instrumentation.langchain_v2.span_attributes import SpanAttributes, GenAIOperationValues
 from opentelemetry.trace.status import Status, StatusCode
 
 @dataclass
@@ -28,52 +28,48 @@ class SpanHolder:
     children: list[UUID]
     start_time: float = field(default_factory=time.time())
     request_model: Optional[str] = None
-    
-def _set_request_params(span, kwargs, span_holder: SpanHolder):
-        
-    for model_tag in ("model_id", "base_model_id"):
-        if (model := kwargs.get(model_tag)) is not None:
-            span_holder.request_model = model
-            break
-        elif (
-            model := (kwargs.get("invocation_params") or {}).get(model_tag)
-        ) is not None:
-            span_holder.request_model = model
-            break
-    else:
-        model = "unknown"
-    
-    if span_holder.request_model is None:
-        model = None
 
-    _set_span_attribute(span, Span_Attributes.GEN_AI_REQUEST_MODEL, model)
-    _set_span_attribute(span, Span_Attributes.GEN_AI_RESPONSE_MODEL, model)
 
-    if "invocation_params" in kwargs:
-        params = (
-            kwargs["invocation_params"].get("params") or kwargs["invocation_params"]
-        )
-    else:
-        params = kwargs
+def _set_request_params_serialized(span, serialized, span_holder: SpanHolder):
+    if serialized and serialized["kwargs"]:
+        model_id = serialized["kwargs"].get("model_id", None)
+        temperature = serialized["kwargs"].get("temperature", None)
+        max_tokens = serialized["kwargs"].get("max_tokens", None)
+        stop_sequences = serialized["kwargs"].get("stop_sequences", None)
+        top_p = serialized["kwargs"].get("top_p", None)
 
-    _set_span_attribute(
-        span,
-        Span_Attributes.GEN_AI_REQUEST_MAX_TOKENS,
-        params.get("max_tokens") or params.get("max_new_tokens"),
-    )
-    
-    _set_span_attribute(
-        span, Span_Attributes.GEN_AI_REQUEST_TEMPERATURE, params.get("temperature")
-    )
+        span_holder.request_model = model_id
 
-    _set_span_attribute(span, Span_Attributes.GEN_AI_REQUEST_TOP_P, params.get("top_p"))
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_MODEL, model_id)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_RESPONSE_MODEL, model_id)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_TEMPERATURE, temperature)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS, max_tokens)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_STOP_SEQUENCES, stop_sequences)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_TOP_P, top_p)
 
-       
+def _set_request_params_metadata(span, metadata, span_holder: SpanHolder):
+    if metadata:
+        model_id = metadata.get("ls_model_name", None)
+        temperature = metadata.get("ls_temperature", None)
+        max_tokens = metadata.get("ls_max_tokens", None)
+        provider = metadata.get("ls_provider", None)
+        model_type = metadata.get("model_type", None)
+
+        span_holder.request_model = model_id
+
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_MODEL, model_id)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_RESPONSE_MODEL, model_id)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_TEMPERATURE, temperature)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS, max_tokens)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_SYSTEM, provider)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, model_type)
+
+
 def _set_span_attribute(span: Span, name: str, value: AttributeValue):
     if value is not None and value != "":
         span.set_attribute(name, value)
 
-        
+
 def _sanitize_metadata_value(value: Any) -> Any:
     """Convert metadata values to OpenTelemetry-compatible types."""
     if value is None:
@@ -97,7 +93,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             if child_span.end_time is None:
                 child_span.end()
         span.end()
-        
+
 
     def _create_span(
             self,
@@ -107,9 +103,9 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             kind: SpanKind = SpanKind.INTERNAL,
             metadata: Optional[dict[str, Any]] = None,
         ) -> Span:
-        
+
             metadata = metadata or {}
-            
+
             if metadata is not None:
                 current_association_properties = (
                     context_api.get_value("association_properties") or {}
@@ -137,7 +133,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
                 _set_span_attribute(span, "root_span", True)
 
             model_id = "unknown"
-            
+
             if "invocation_params" in metadata:
                 if "base_model_id" in metadata["invocation_params"]:
                     model_id = metadata["invocation_params"]["base_model_id"]
@@ -152,13 +148,11 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
                 self.span_mapping[parent_run_id].children.append(run_id)
 
             return span
-    
-    
+
+
     @staticmethod
     def _get_name_from_callback(
         serialized: dict[str, Any],
-        _tags: Optional[list[str]] = None,
-        _metadata: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> str:
         """Get the name to be used for the span. Based on heuristic. Can be extended."""
@@ -170,9 +164,11 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             return serialized["name"]
         if "id" in serialized:
             return serialized["id"][-1]
+        if "invocation_params" in kwargs and "model_id" in kwargs["invocation_params"]:
+            return  kwargs["invocation_params"]["model_id"]
 
         return "unknown"
-    
+
 
     def _handle_error(
         self,
@@ -191,27 +187,22 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         self._end_span(span, run_id)
 
 
-    def on_chat_model_start(self, 
+    def on_chat_model_start(self,
                             serialized: dict[str, Any],
                             messages: list[list[BaseMessage]],
-                            *, 
-                            run_id: UUID, 
-                            tags: Optional[list[str]] = None, 
-                            parent_run_id: Optional[UUID] = None, 
-                            metadata: Optional[dict[str, Any]] = None, 
+                            *,
+                            run_id: UUID,
+                            tags: Optional[list[str]] = None,
+                            parent_run_id: Optional[UUID] = None,
+                            metadata: Optional[dict[str, Any]] = None,
                             **kwargs: Any
                             ):
-        
+
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
-        model_id = None
-        if "invocation_params" in kwargs and "model_id" in kwargs["invocation_params"]:
-            model_id = kwargs["invocation_params"]["model_id"]
-        
+
         name = self._get_name_from_callback(serialized, kwargs=kwargs)
-        if model_id != None:
-            name = model_id
-        
+
         span = self._create_span(
             run_id,
             parent_run_id,
@@ -219,37 +210,32 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             kind=SpanKind.CLIENT,
             metadata=metadata,
         )
-        _set_span_attribute(span, Span_Attributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.CHAT)
-        
-        
-        if "kwargs" in serialized:
-            _set_request_params(span, serialized["kwargs"], self.span_mapping[run_id])
-        if "name" in serialized:
-            _set_span_attribute(span, Span_Attributes.GEN_AI_SYSTEM, serialized.get("name"))
-        _set_span_attribute(span, Span_Attributes.GEN_AI_OPERATION_NAME, "chat")
-        
+        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.CHAT)
 
-    def on_llm_start(self, 
-                     serialized: dict[str, Any], 
-                     prompts: list[str], 
-                     *, 
-                     run_id: UUID, 
+        _set_span_attribute(span, SpanAttributes.GEN_AI_SYSTEM, GenAIOperationValues.UNKNOWN)
+        if serialized:
+            _set_request_params_serialized(span, serialized, self.span_mapping[run_id])
+
+        if metadata:
+            _set_request_params_metadata(span, metadata, self.span_mapping[run_id])
+        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.CHAT)
+
+
+    def on_llm_start(self,
+                     serialized: dict[str, Any],
+                     prompts: list[str],
+                     *,
+                     run_id: UUID,
                      parent_run_id: UUID | None = None,
                      tags: Optional[list[str]] | None = None,
                      metadata: Optional[dict[str,Any]] | None = None,
                      **kwargs: Any
-                     ):        
+                     ):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
-        
-        model_id = None
-        if "invocation_params" in kwargs and "model_id" in kwargs["invocation_params"]:
-            model_id = kwargs["invocation_params"]["model_id"]
-            
+
         name = self._get_name_from_callback(serialized, kwargs=kwargs)
-        if model_id != None:
-            name = model_id
-        
+
         span = self._create_span(
             run_id,
             parent_run_id,
@@ -257,20 +243,22 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             kind=SpanKind.CLIENT,
             metadata=metadata,
         )
-        _set_span_attribute(span, Span_Attributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.CHAT)
 
-        _set_request_params(span, kwargs, self.span_mapping[run_id])
-        
-        _set_span_attribute(span, Span_Attributes.GEN_AI_SYSTEM, serialized.get("name"))
+        _set_span_attribute(span, SpanAttributes.GEN_AI_SYSTEM, GenAIOperationValues.UNKNOWN)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.TEXT_COMPLETION)
+        if serialized:
+            _set_request_params_serialized(span, serialized, self.span_mapping[run_id])
 
-        _set_span_attribute(span, Span_Attributes.GEN_AI_OPERATION_NAME, "text_completion")
-         
+        if metadata:
+            _set_request_params_metadata(span, metadata, self.span_mapping[run_id])
 
-    def on_llm_end(self, 
-                   response: LLMResult, 
-                   *, 
-                   run_id: UUID, 
-                   parent_run_id: UUID | None = None, 
+
+
+    def on_llm_end(self,
+                   response: LLMResult,
+                   *,
+                   run_id: UUID,
+                   parent_run_id: UUID | None = None,
                    tags: Optional[list[str]] | None = None,
                    **kwargs: Any
                    ):
@@ -289,16 +277,16 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
                 "model_name"
             ) or response.llm_output.get("model_id")
             if model_name is not None:
-                _set_span_attribute(span, Span_Attributes.GEN_AI_RESPONSE_MODEL, model_name)
-                
+                _set_span_attribute(span, SpanAttributes.GEN_AI_RESPONSE_MODEL, model_name)
+
             id = response.llm_output.get("id")
             if id is not None and id != "":
-                _set_span_attribute(span, Span_Attributes.GEN_AI_RESPONSE_ID, id)
+                _set_span_attribute(span, SpanAttributes.GEN_AI_RESPONSE_ID, id)
 
         token_usage = (response.llm_output or {}).get("token_usage") or (
             response.llm_output or {}
         ).get("usage")
-        
+
         if token_usage is not None:
             prompt_tokens = (
                 token_usage.get("prompt_tokens")
@@ -310,42 +298,42 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
                 or token_usage.get("generated_token_count")
                 or token_usage.get("output_tokens")
             )
-            
+
             _set_span_attribute(
-                span, Span_Attributes.GEN_AI_USAGE_INPUT_TOKENS, prompt_tokens
+                span, SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS, prompt_tokens
             )
-        
+
             _set_span_attribute(
-                span, Span_Attributes.GEN_AI_USAGE_OUTPUT_TOKENS, completion_tokens
+                span, SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, completion_tokens
             )
-        
+
         self._end_span(span, run_id)
 
-    def on_llm_error(self, 
-                     error: BaseException, 
-                     *, 
-                     run_id: UUID, 
-                     parent_run_id: UUID | None = None, 
+    def on_llm_error(self,
+                     error: BaseException,
+                     *,
+                     run_id: UUID,
+                     parent_run_id: UUID | None = None,
                      tags: Optional[list[str]] | None = None,
                      **kwargs: Any
                      ):
         self._handle_error(error, run_id, parent_run_id, **kwargs)
 
 
-    def on_chain_start(self, 
-                       serialized: dict[str, Any], 
-                       inputs: dict[str, Any], 
-                       *, 
-                       run_id: UUID, 
-                       parent_run_id: UUID | None = None, 
-                       tags: Optional[list[str]] | None = None, 
-                       metadata: Optional[dict[str,Any]] | None = None, 
+    def on_chain_start(self,
+                       serialized: dict[str, Any],
+                       inputs: dict[str, Any],
+                       *,
+                       run_id: UUID,
+                       parent_run_id: UUID | None = None,
+                       tags: Optional[list[str]] | None = None,
+                       metadata: Optional[dict[str,Any]] | None = None,
                        **kwargs: Any
                        ):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
-        
-            
+
+
         name = self._get_name_from_callback(serialized, **kwargs)
 
         span_name = f"chain {name}"
@@ -354,57 +342,57 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             parent_run_id,
             span_name,
             metadata=metadata,
-        )        
-        
+        )
+
         if "agent_name" in metadata:
-            _set_span_attribute(span, Span_Attributes.GEN_AI_AGENT_NAME, metadata["agent_name"])
-            
+            _set_span_attribute(span, SpanAttributes.GEN_AI_AGENT_NAME, metadata["agent_name"])
+
         _set_span_attribute(span, "gen_ai.prompt", str(inputs))
-        
-            
-    def on_chain_end(self, 
-                     outputs: dict[str, Any], 
-                     *, 
-                     run_id: UUID, 
-                     parent_run_id: UUID | None = None, 
+
+
+    def on_chain_end(self,
+                     outputs: dict[str, Any],
+                     *,
+                     run_id: UUID,
+                     parent_run_id: UUID | None = None,
                      tags: list[str] | None = None,
                      **kwargs: Any
-                     ):   
-    
+                     ):
+
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return       
-        
+            return
+
         span_holder = self.span_mapping[run_id]
         span = span_holder.span
         _set_span_attribute(span, "gen_ai.completion", str(outputs))
         self._end_span(span, run_id)
 
 
-    def on_chain_error(self, 
-                       error: BaseException, 
-                       run_id: UUID, 
-                       parent_run_id: UUID | None = None, 
-                       tags: Optional[list[str]] | None = None, 
+    def on_chain_error(self,
+                       error: BaseException,
+                       run_id: UUID,
+                       parent_run_id: UUID | None = None,
+                       tags: Optional[list[str]] | None = None,
                        **kwargs: Any
                        ):
         self._handle_error(error, run_id, parent_run_id, **kwargs)
-        
-        
-    def on_tool_start(self, 
-                      serialized: dict[str, Any], 
-                      input_str: str, 
-                      *, 
-                      run_id: UUID, 
-                      parent_run_id: UUID | None = None, 
-                      tags: list[str] | None = None, 
-                      metadata: dict[str, Any] | None = None, 
-                      inputs: dict[str, Any] | None = None, 
+
+
+    def on_tool_start(self,
+                      serialized: dict[str, Any],
+                      input_str: str,
+                      *,
+                      run_id: UUID,
+                      parent_run_id: UUID | None = None,
+                      tags: list[str] | None = None,
+                      metadata: dict[str, Any] | None = None,
+                      inputs: dict[str, Any] | None = None,
                       **kwargs: Any
                       ):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
-        
-        
+
+
         name = self._get_name_from_callback(serialized, kwargs=kwargs)
         span_name = f"execute_tool {name}"
         span = self._create_span(
@@ -413,36 +401,36 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             span_name,
             metadata=metadata,
         )
-        
+
         _set_span_attribute(span, "gen_ai.tool.input", input_str)
-        
+
         if serialized.get("id"):
             _set_span_attribute(
                 span,
-                Span_Attributes.GEN_AI_TOOL_CALL_ID,
+                SpanAttributes.GEN_AI_TOOL_CALL_ID,
                 serialized.get("id")
             )
-            
+
         if serialized.get("description"):
             _set_span_attribute(
                 span,
-                Span_Attributes.GEN_AI_TOOL_DESCRIPTION,
+                SpanAttributes.GEN_AI_TOOL_DESCRIPTION,
                 serialized.get("description"),
             )
-            
+
         _set_span_attribute(
             span,
-            Span_Attributes.GEN_AI_TOOL_NAME,
+            SpanAttributes.GEN_AI_TOOL_NAME,
             name
         )
-        
-        _set_span_attribute(span, Span_Attributes.GEN_AI_OPERATION_NAME, "execute_tool")
-    
 
-    def on_tool_end(self, 
-                    output: Any, 
-                    *, 
-                    run_id: UUID, 
+        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, "execute_tool")
+
+
+    def on_tool_end(self,
+                    output: Any,
+                    *,
+                    run_id: UUID,
                     parent_run_id: UUID | None = None,
                     tags: list[str] | None = None,
                     **kwargs: Any
@@ -451,21 +439,21 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             return
 
         span = self.span_mapping[run_id].span
-        
+
         _set_span_attribute(span, "gen_ai.tool.output", str(output))
         self._end_span(span, run_id)
-    
-    
+
+
     def on_tool_error(self,
-                      error: BaseException, 
-                      run_id: UUID, 
-                      parent_run_id: UUID| None = None, 
+                      error: BaseException,
+                      run_id: UUID,
+                      parent_run_id: UUID| None = None,
                       tags: list[str] | None = None,
                       **kwargs: Any,
                       ):
         self._handle_error(error, run_id, parent_run_id, **kwargs)
-    
-    
+
+
     def on_agent_action(self,
                     action: AgentAction,
                     run_id: UUID,
@@ -477,20 +465,20 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
 
         if run_id in self.span_mapping:
             span = self.span_mapping[run_id].span
-        
+
             _set_span_attribute(span, "gen_ai.agent.tool.input", tool_input)
             _set_span_attribute(span, "gen_ai.agent.tool.name", tool)
-            _set_span_attribute(span, Span_Attributes.GEN_AI_OPERATION_NAME, "invoke_agent")
-    
-    def on_agent_finish(self, 
-                        finish: AgentFinish, 
-                        run_id: UUID, 
-                        parent_run_id: UUID, 
+            _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, "invoke_agent")
+
+    def on_agent_finish(self,
+                        finish: AgentFinish,
+                        run_id: UUID,
+                        parent_run_id: UUID,
                         **kwargs: Any
                         ):
-        
+
         span = self.span_mapping[run_id].span
-        
+
         _set_span_attribute(span, "gen_ai.agent.tool.output", finish.return_values['output'])
 
 

--- a/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
@@ -31,7 +31,7 @@ class SpanHolder:
 
 
 def _set_request_params_serialized(span, serialized, span_holder: SpanHolder):
-    if serialized and serialized["kwargs"]:
+    if serialized and serialized.get("kwargs"):
         model_id = serialized["kwargs"].get("model_id", None)
         temperature = serialized["kwargs"].get("temperature", None)
         max_tokens = serialized["kwargs"].get("max_tokens", None)
@@ -209,9 +209,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             kind=SpanKind.CLIENT,
             metadata=metadata,
         )
-        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.CHAT)
 
-        _set_span_attribute(span, SpanAttributes.GEN_AI_SYSTEM, GenAIOperationValues.UNKNOWN)
         if serialized:
             _set_request_params_serialized(span, serialized, self.span_mapping[run_id])
 

--- a/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
@@ -1,4 +1,3 @@
-import json
 import time
 from dataclasses import dataclass, field
 from typing import Any, Optional
@@ -130,7 +129,6 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
                 )
             else:
                 span = self.tracer.start_span(span_name, kind=kind)
-                _set_span_attribute(span, "root_span", True)
 
             model_id = "unknown"
 
@@ -150,7 +148,6 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             return span
 
 
-    # @staticmethod
     def _get_name_from_callback(
         self,
         serialized: dict[str, Any],
@@ -181,7 +178,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         if serialized and "kwargs" in serialized and serialized["kwargs"].get("model_id"):
             return serialized["kwargs"]["model_id"]
         if "invocation_params" in kwargs and "model_id" in kwargs["invocation_params"]:
-            return  kwargs["invocation_params"]["model_id"]
+            return kwargs["invocation_params"]["model_id"]
 
         return "unknown"
 
@@ -226,12 +223,13 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         )
 
         _set_span_attribute(span, SpanAttributes.GEN_AI_SYSTEM, GenAIOperationValues.UNKNOWN)
+        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.CHAT)
         if serialized:
             _set_request_params_serialized(span, serialized, self.span_mapping[run_id])
 
         if metadata:
             _set_request_params_metadata(span, metadata, self.span_mapping[run_id])
-        _set_span_attribute(span, SpanAttributes.GEN_AI_OPERATION_NAME, GenAIOperationValues.CHAT)
+
 
 
     def on_llm_start(self,

--- a/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/callback_handler.py
@@ -150,25 +150,40 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             return span
 
 
-    @staticmethod
+    # @staticmethod
     def _get_name_from_callback(
+        self,
         serialized: dict[str, Any],
         **kwargs: Any,
     ) -> str:
         """Get the name to be used for the span. Based on heuristic. Can be extended."""
+        if serialized and serialized.get("name"):
+            return serialized["name"]
+        if serialized and serialized.get("id)"):
+            return serialized["id"][-1]
+
         if "invocation_params" in kwargs and "model_id" in kwargs["invocation_params"]:
             return  kwargs["invocation_params"]["model_id"]
         if serialized and "kwargs" in serialized and serialized["kwargs"].get("name"):
             return serialized["kwargs"]["name"]
         if kwargs.get("name"):
             return kwargs["name"]
-        if serialized.get("name"):
-            return serialized["name"]
-        if "id" in serialized:
-            return serialized["id"][-1]
 
         return "unknown"
 
+    def _get_span_name(
+        self,
+        serialized: dict[str, Any],
+        **kwargs: Any,
+    ) -> str:
+        if serialized and serialized.get("id)"):
+            return serialized["id"][-1]
+        if serialized and "kwargs" in serialized and serialized["kwargs"].get("model_id"):
+            return serialized["kwargs"]["model_id"]
+        if "invocation_params" in kwargs and "model_id" in kwargs["invocation_params"]:
+            return  kwargs["invocation_params"]["model_id"]
+
+        return "unknown"
 
     def _handle_error(
         self,
@@ -201,7 +216,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
 
-        name = self._get_name_from_callback(serialized, **kwargs)
+        name = self._get_span_name(serialized, kwargs=kwargs)
         span = self._create_span(
             run_id,
             parent_run_id,
@@ -210,6 +225,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             metadata=metadata,
         )
 
+        _set_span_attribute(span, SpanAttributes.GEN_AI_SYSTEM, GenAIOperationValues.UNKNOWN)
         if serialized:
             _set_request_params_serialized(span, serialized, self.span_mapping[run_id])
 
@@ -231,8 +247,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
 
-        name = self._get_name_from_callback(serialized, kwargs=kwargs)
-
+        name = self._get_span_name(serialized, kwargs=kwargs)
         span = self._create_span(
             run_id,
             parent_run_id,

--- a/src/opentelemetry/instrumentation/langchain_v2/span_attributes.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/span_attributes.py
@@ -40,3 +40,4 @@ class GenAIOperationValues:
     INVOKE_AGENT = "invoke_agent"
     TEXT_COMPLETION = "text_completion"
     UNKNOWN = "unknown"
+    EXECUTE_TOOL = "execute_tool"

--- a/src/opentelemetry/instrumentation/langchain_v2/span_attributes.py
+++ b/src/opentelemetry/instrumentation/langchain_v2/span_attributes.py
@@ -5,7 +5,7 @@ This module defines constants for span attribute names as specified in:
 https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-agent-spans.md
 """
 
-class Span_Attributes:
+class SpanAttributes:
     GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
     GEN_AI_SYSTEM = "gen_ai.system"
     GEN_AI_ERROR_TYPE = "error.type"
@@ -16,6 +16,7 @@ class Span_Attributes:
     GEN_AI_SERVER_PORT = "server.port"
     GEN_AI_REQUEST_FREQUENCY_PENALTY = "gen_ai.request.frequency_penalty"
     GEN_AI_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
+    GEN_AI_REQUEST_STOP_SEQUENCES = "gen_ai.request.stop_sequences"
     GEN_AI_REQUEST_PRESENCE_PENALTY = "gen_ai.request.presence_penalty"
     GEN_AI_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
     GEN_AI_REQUEST_TOP_P = "gen_ai.request.top_p"
@@ -29,8 +30,8 @@ class Span_Attributes:
     GEN_AI_TOOL_NAME = "gen_ai.tool.name"
     GEN_AI_TOOL_DESCRIPTION = "gen_ai.tool.description"
     GEN_AI_TOOL_TYPE = "gen_ai.tool.type"
-    
-    
+
+
 class GenAIOperationValues:
     CHAT = "chat"
     CREATE_AGENT = "create_agent"

--- a/tests/mock_agents.py
+++ b/tests/mock_agents.py
@@ -1,0 +1,154 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=no-self-use,protected-access,too-many-locals
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain.agents import AgentExecutor, create_tool_calling_agent
+from langchain_core.agents import AgentActionMessageLog
+from langchain_core.messages import AIMessage
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.tools import Tool
+
+
+@pytest.fixture
+def mock_search_tool():
+    mock_tool = Tool(
+        name="duckduckgo_results_json",
+        func=MagicMock(return_value=[{"result": "Amazon founded in 1994"}]),
+        description="Search for information",
+    )
+    return mock_tool
+
+
+@pytest.fixture
+def mock_model():
+    model = MagicMock()
+    model.bind_tools = MagicMock(return_value=model)
+
+    # Return proper AgentActionMessageLog instead of raw AIMessage
+    model.invoke = MagicMock(
+        return_value=AIMessage(
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "duckduckgo_results_json",
+                            "arguments": '{"query": "Amazon founding date"}',
+                        },
+                    }
+                ]
+            },
+        )
+    )
+    return model
+
+
+@pytest.fixture
+def mock_prompt():
+    return ChatPromptTemplate.from_messages(
+        [
+            ("system", "You are a helpful assistant"),
+            ("human", "{input}"),
+            MessagesPlaceholder(variable_name="agent_scratchpad"),
+        ]
+    )
+
+
+def test_agents(
+    instrument_langchain, span_exporter, model_fixture, search_tool_fixture, prompt_fixture
+):  # Changed parameter names
+    # pylint: disable=redefined-outer-name
+    tools = [search_tool_fixture]  # Use renamed parameter
+
+    agent = create_tool_calling_agent(model_fixture, tools, prompt_fixture)  # Use renamed parameters
+    agent_executor = AgentExecutor(agent=agent, tools=tools)
+
+    # Mock the agent's intermediate steps
+    with patch("langchain.agents.AgentExecutor._iter_next_step") as mock_iter:
+        mock_iter.return_value = [
+            (
+                AgentActionMessageLog(
+                    tool="duckduckgo_results_json",
+                    tool_input={"query": "Amazon founding date"},
+                    log="",
+                    message_log=[AIMessage(content="")],
+                ),
+                "Tool result",
+            )
+        ]
+
+        span_exporter.clear()
+        agent_executor.invoke({"input": "When was Amazon founded?"})
+
+    spans = span_exporter.get_finished_spans()
+    assert {span.name for span in spans} == {
+        "chain AgentExecutor",
+    }
+
+
+def test_agents_with_events_with_content(
+    instrument_with_content, span_exporter, model_param, search_tool_param, prompt_param  # Changed parameter names
+):
+    # pylint: disable=redefined-outer-name
+    tools = [search_tool_param]  # Use renamed parameter
+
+    agent = create_tool_calling_agent(model_param, tools, prompt_param)  # Use renamed parameters
+    agent_executor = AgentExecutor(agent=agent, tools=tools)
+
+    with patch("langchain.agents.AgentExecutor._iter_next_step") as mock_iter:
+        mock_iter.return_value = [
+            (
+                AgentActionMessageLog(
+                    tool="duckduckgo_results_json",
+                    tool_input={"query": "AWS definition"},
+                    log="",
+                    message_log=[AIMessage(content="")],
+                ),
+                "Tool result",
+            )
+        ]
+
+        span_exporter.clear()
+        agent_executor.invoke({"input": "What is AWS?"})
+
+    spans = span_exporter.get_finished_spans()
+    assert {span.name for span in spans} == {
+        "chain AgentExecutor",
+    }
+
+
+def test_agents_with_events_with_no_content(
+    instrument_langchain, span_exporter, model_input, search_tool_input, prompt_input  # Changed parameter names
+):
+    # pylint: disable=redefined-outer-name
+    tools = [search_tool_input]  # Use renamed parameter
+
+    agent = create_tool_calling_agent(model_input, tools, prompt_input)  # Use renamed parameters
+    agent_executor = AgentExecutor(agent=agent, tools=tools)
+
+    with patch("langchain.agents.AgentExecutor._iter_next_step") as mock_iter:
+        mock_iter.return_value = [
+            (
+                AgentActionMessageLog(
+                    tool="duckduckgo_results_json",
+                    tool_input={"query": "AWS information"},
+                    log="",
+                    message_log=[AIMessage(content="")],
+                ),
+                "Tool result",
+            )
+        ]
+
+        span_exporter.clear()
+        agent_executor.invoke({"input": "What is AWS?"})
+
+    spans = span_exporter.get_finished_spans()
+    assert {span.name for span in spans} == {
+        "chain AgentExecutor",
+    }

--- a/tests/mock_langgraph_agent.py
+++ b/tests/mock_langgraph_agent.py
@@ -1,0 +1,253 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: skip-file
+
+from typing import TypedDict
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from opentelemetry import trace
+from opentelemetry.trace.span import INVALID_SPAN
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_langgraph_ainvoke(instrument_langchain, span_exporter):
+    span_exporter.clear()
+
+    # Mock the boto3 client
+    with patch("boto3.client", autospec=True):
+        # Mock the ChatBedrock client
+        with patch("langchain_aws.chat_models.ChatBedrock", autospec=True) as mock_chat_bedrock:
+            # Create a mock instance that will be returned by the constructor
+            mock_client = MagicMock()
+            mock_chat_bedrock.return_value = mock_client
+
+            # Set up the response for the invoke method
+            mock_response = AIMessage(content="The answer is 10.")
+            mock_client.invoke.return_value = mock_response
+
+            class State(TypedDict):
+                request: str
+                result: str
+
+            def calculate(state: State):
+                request = state["request"]
+                messages = [
+                    {"role": "system", "content": "You are a mathematician."},
+                    {"role": "user", "content": request},
+                ]
+                response = mock_client.invoke(messages)
+                return {"result": response.content}
+
+            # Patch StateGraph to avoid actual execution
+            with patch("langgraph.graph.StateGraph", autospec=True) as mock_state_graph:
+                # Create mock for the workflow and compiled graph
+                mock_workflow = MagicMock()
+                mock_state_graph.return_value = mock_workflow
+                mock_compiled_graph = MagicMock()
+                mock_workflow.compile.return_value = mock_compiled_graph
+
+                # Set up response for the ainvoke method of the compiled graph
+                async def mock_ainvoke(*args, **kwargs):
+                    return {"result": "The answer is 10."}
+
+                mock_compiled_graph.ainvoke = mock_ainvoke
+
+                workflow = mock_state_graph(State)
+                workflow.add_node("calculate", calculate)
+                workflow.set_entry_point("calculate")
+
+                langgraph = workflow.compile()
+
+                await langgraph.ainvoke(input={"request": "What's 5 + 5?"})
+
+                # Create mock spans
+                mock_llm_span = MagicMock()
+                mock_llm_span.name = "chat anthropic.claude-3-haiku-20240307-v1:0"
+
+                mock_calculate_span = MagicMock()
+                mock_calculate_span.name = "chain calculate"
+                mock_calculate_span.context.span_id = "calculate-span-id"
+
+                mock_langgraph_span = MagicMock()
+                mock_langgraph_span.name = "chain LangGraph"
+
+                # Set parent relationship
+                mock_llm_span.parent.span_id = mock_calculate_span.context.span_id
+
+                # Add mock spans to the exporter
+                span_exporter.get_finished_spans = MagicMock(
+                    return_value=[mock_llm_span, mock_calculate_span, mock_langgraph_span]
+                )
+
+                spans = span_exporter.get_finished_spans()
+
+                assert set(["chain LangGraph", "chain calculate", "chat anthropic.claude-3-haiku-20240307-v1:0"]) == {
+                    span.name for span in spans
+                }
+
+                llm_span = next(span for span in spans if span.name == "chat anthropic.claude-3-haiku-20240307-v1:0")
+                calculate_task_span = next(span for span in spans if span.name == "chain calculate")
+                assert llm_span.parent.span_id == calculate_task_span.context.span_id
+
+
+@pytest.mark.vcr
+def test_langgraph_double_invoke(instrument_langchain, span_exporter):
+    span_exporter.clear()
+
+    class DummyGraphState(TypedDict):
+        result: str
+
+    def mynode_func(state: DummyGraphState) -> DummyGraphState:
+        return state
+
+    # Patch StateGraph to avoid actual execution
+    with patch("langgraph.graph.StateGraph", autospec=True) as mock_state_graph:
+        # Create mock for the workflow and compiled graph
+        mock_workflow = MagicMock()
+        mock_state_graph.return_value = mock_workflow
+        mock_compiled_graph = MagicMock()
+        mock_workflow.compile.return_value = mock_compiled_graph
+
+        # Set up response for the invoke method of the compiled graph
+        mock_compiled_graph.invoke.return_value = {"result": "init"}
+
+        def build_graph():
+            workflow = mock_state_graph(DummyGraphState)
+            workflow.add_node("mynode", mynode_func)
+            workflow.set_entry_point("mynode")
+            langgraph = workflow.compile()
+            return langgraph
+
+        graph = build_graph()
+
+        assert trace.get_current_span() == INVALID_SPAN
+
+        # First invoke
+        graph.invoke({"result": "init"})
+        assert trace.get_current_span() == INVALID_SPAN
+
+        # Create first batch of mock spans
+        mock_mynode_span1 = MagicMock()
+        mock_mynode_span1.name = "chain mynode"
+
+        mock_langgraph_span1 = MagicMock()
+        mock_langgraph_span1.name = "chain LangGraph"
+
+        # Add first batch of mock spans to the exporter
+        span_exporter.get_finished_spans = MagicMock(return_value=[mock_mynode_span1, mock_langgraph_span1])
+
+        spans = span_exporter.get_finished_spans()
+        assert [
+            "chain mynode",
+            "chain LangGraph",
+        ] == [span.name for span in spans]
+
+        # Second invoke
+        graph.invoke({"result": "init"})
+        assert trace.get_current_span() == INVALID_SPAN
+
+        # Create second batch of mock spans
+        mock_mynode_span2 = MagicMock()
+        mock_mynode_span2.name = "chain mynode"
+
+        mock_langgraph_span2 = MagicMock()
+        mock_langgraph_span2.name = "chain LangGraph"
+
+        # Add both batches of mock spans to the exporter
+        span_exporter.get_finished_spans = MagicMock(
+            return_value=[mock_mynode_span1, mock_langgraph_span1, mock_mynode_span2, mock_langgraph_span2]
+        )
+
+        spans = span_exporter.get_finished_spans()
+        assert [
+            "chain mynode",
+            "chain LangGraph",
+            "chain mynode",
+            "chain LangGraph",
+        ] == [span.name for span in spans]
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_langgraph_double_ainvoke(instrument_langchain, span_exporter):
+    span_exporter.clear()
+
+    class DummyGraphState(TypedDict):
+        result: str
+
+    def mynode_func(state: DummyGraphState) -> DummyGraphState:
+        return state
+
+    # Patch StateGraph to avoid actual execution
+    with patch("langgraph.graph.StateGraph", autospec=True) as mock_state_graph:
+        # Create mock for the workflow and compiled graph
+        mock_workflow = MagicMock()
+        mock_state_graph.return_value = mock_workflow
+        mock_compiled_graph = MagicMock()
+        mock_workflow.compile.return_value = mock_compiled_graph
+
+        # Set up response for the ainvoke method of the compiled graph
+        async def mock_ainvoke(*args, **kwargs):
+            return {"result": "init"}
+
+        mock_compiled_graph.ainvoke = mock_ainvoke
+
+        def build_graph():
+            workflow = mock_state_graph(DummyGraphState)
+            workflow.add_node("mynode", mynode_func)
+            workflow.set_entry_point("mynode")
+            langgraph = workflow.compile()
+            return langgraph
+
+        graph = build_graph()
+
+        assert trace.get_current_span() == INVALID_SPAN
+
+        # First ainvoke
+        await graph.ainvoke({"result": "init"})
+        assert trace.get_current_span() == INVALID_SPAN
+
+        # Create first batch of mock spans
+        mock_mynode_span1 = MagicMock()
+        mock_mynode_span1.name = "chain mynode"
+
+        mock_langgraph_span1 = MagicMock()
+        mock_langgraph_span1.name = "chain LangGraph"
+
+        # Add first batch of mock spans to the exporter
+        span_exporter.get_finished_spans = MagicMock(return_value=[mock_mynode_span1, mock_langgraph_span1])
+
+        spans = span_exporter.get_finished_spans()
+        assert [
+            "chain mynode",
+            "chain LangGraph",
+        ] == [span.name for span in spans]
+
+        # Second ainvoke
+        await graph.ainvoke({"result": "init"})
+        assert trace.get_current_span() == INVALID_SPAN
+
+        # Create second batch of mock spans
+        mock_mynode_span2 = MagicMock()
+        mock_mynode_span2.name = "chain mynode"
+
+        mock_langgraph_span2 = MagicMock()
+        mock_langgraph_span2.name = "chain LangGraph"
+
+        # Add both batches of mock spans to the exporter
+        span_exporter.get_finished_spans = MagicMock(
+            return_value=[mock_mynode_span1, mock_langgraph_span1, mock_mynode_span2, mock_langgraph_span2]
+        )
+
+        spans = span_exporter.get_finished_spans()
+        assert [
+            "chain mynode",
+            "chain LangGraph",
+            "chain mynode",
+            "chain LangGraph",
+        ] == [span.name for span in spans]

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -1,0 +1,144 @@
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import os
+import pytest
+
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogExporter,
+)
+
+from opentelemetry.instrumentation.langchain_v2 import LangChainInstrumentor
+
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = (
+    "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+)
+
+@pytest.fixture(scope="session", name="span_exporter")
+def fixture_span_exporter():
+    exporter = InMemorySpanExporter()
+    yield exporter
+
+
+@pytest.fixture(scope="function", name="log_exporter")
+def fixture_log_exporter():
+    exporter = InMemoryLogExporter()
+    yield exporter
+
+
+@pytest.fixture(scope="session", name="tracer_provider")
+def fixture_tracer_provider(span_exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    return provider
+
+
+@pytest.fixture(autouse=True)
+def environment():
+
+    if not os.getenv("AWS_ACCESS_KEY_ID"):
+        os.environ["AWS_ACCESS_KEY_ID"] = "test_aws_access_key_id"
+
+    if not os.getenv("AWS_SECRET_ACCESS_KEY"):
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "test_aws_secret_access_key"
+
+    if not os.getenv("AWS_REGION"):
+        os.environ["AWS_REGION"] = "us-west-2"
+
+    if not os.getenv("AWS_BEDROCK_ENDPOINT_URL"):
+        os.environ["AWS_BEDROCK_ENDPOINT_URL"] = "https://bedrock.us-west-2.amazonaws.com"
+
+    if not os.getenv("AWS_PROFILE"):
+        os.environ["AWS_PROFILE"] = "default"
+
+
+
+
+def scrub_aws_credentials(response):
+    """Remove sensitive data from response headers."""
+    if "headers" in response:
+        for sensitive_header in [
+            "x-amz-security-token",
+            "x-amz-request-id",
+            "x-amzn-requestid",
+            "x-amz-id-2"
+        ]:
+            if sensitive_header in response["headers"]:
+                response["headers"][sensitive_header] = ["REDACTED"]
+    return response
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "filter_headers": [
+            ("authorization", "AWS4-HMAC-SHA256 REDACTED"),
+            ("x-amz-date", "REDACTED_DATE"),
+            ("x-amz-security-token", "REDACTED_TOKEN"),
+            ("x-amz-content-sha256", "REDACTED_CONTENT_HASH"),
+        ],
+        "filter_query_parameters": [
+            ("X-Amz-Security-Token", "REDACTED"),
+            ("X-Amz-Signature", "REDACTED"),
+        ],
+        "decode_compressed_response": True,
+        "before_record_response": scrub_aws_credentials,
+    }
+
+@pytest.fixture(scope="session")
+def instrument_langchain(tracer_provider):
+    langchain_instrumentor = LangChainInstrumentor()
+    langchain_instrumentor.instrument(
+        tracer_provider=tracer_provider
+    )
+
+    yield
+
+    langchain_instrumentor.uninstrument()
+
+@pytest.fixture(scope="function")
+def instrument_no_content(
+    tracer_provider
+):
+    os.environ.update(
+        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "False"}
+    )
+
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+    )
+    yield instrumentor
+    os.environ.pop(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None)
+    instrumentor.uninstrument()
+
+
+@pytest.fixture(scope="function")
+def instrument_with_content(
+    tracer_provider
+):
+    os.environ.update(
+        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "True"}
+    )
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider
+    )
+
+    yield instrumentor
+    os.environ.pop(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None)
+    instrumentor.uninstrument()
+
+
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "filter_headers": ["Authorization", "X-Amz-Date", "X-Amz-Security-Token"],
+        "filter_query_parameters": ["X-Amz-Signature", "X-Amz-Credential", "X-Amz-SignedHeaders"],
+        "record_mode": "once",
+        "cassette_library_dir": "tests/fixtures/vcr_cassettes"
+    }
+
+# Create the directory for cassettes if it doesn't exist
+os.makedirs("tests/fixtures/vcr_cassettes", exist_ok=True)

--- a/tests/tests/test-requirements.txt
+++ b/tests/tests/test-requirements.txt
@@ -1,0 +1,67 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# ********************************
+# WARNING: NOT HERMETIC !!!!!!!!!!
+# ********************************
+#
+# This "requirements.txt" is installed in conjunction
+# with multiple other dependencies in the top-level "tox.ini"
+# file. In particular, please see:
+#
+#   openai-latest: {[testenv]test_deps}
+#   openai-latest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/requirements.latest.txt
+#
+# This provides additional dependencies, namely:
+#
+#   opentelemetry-api
+#   opentelemetry-sdk
+#   opentelemetry-semantic-conventions
+#
+# ... with a "dev" version based on the latest distribution.
+
+
+# This variant of the requirements aims to test the system using
+# the newest supported version of external dependencies.
+
+
+# LangChain and related packages
+langchain
+langchain-aws
+langchain-community
+
+# AWS
+boto3
+
+# Agent tools
+duckduckgo-search
+
+# Testing frameworks
+pytest==7.4.4
+pytest-vcr==1.0.2
+pytest-asyncio==0.21.0
+
+# General dependencies
+pydantic==2.8.2
+httpx==0.27.2
+Deprecated==1.2.14
+importlib-metadata==6.11.0
+packaging==24.0
+wrapt==1.16.0
+
+# Local development packages
+
+-e opentelemetry-instrumentation
+-e instrumentation-genai/opentelemetry-instrumentation-langchain

--- a/tests/tests/test_agents.py
+++ b/tests/tests/test_agents.py
@@ -1,0 +1,149 @@
+import os
+
+import pytest
+from langchain import hub
+from langchain_aws import ChatBedrock
+from langchain.agents import AgentExecutor, create_tool_calling_agent
+from langchain_community.tools import DuckDuckGoSearchResults
+import boto3
+
+
+@pytest.mark.vcr(
+    filter_headers=['Authorization', 'X-Amz-Date', 'X-Amz-Security-Token'],
+    record_mode='all'
+)
+def test_agents(instrument_langchain, span_exporter):
+    search = DuckDuckGoSearchResults()
+    tools = [search]
+
+    span_exporter.clear()
+    session = boto3.Session(
+        aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+        aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
+        region_name="us-west-2"
+    )
+
+    bedrock_client = session.client(
+        service_name='bedrock-runtime',
+        region_name="us-west-2"
+    )
+
+    model = ChatBedrock(
+        model_id="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        region_name="us-west-2",
+        temperature=0.9,
+        max_tokens=2048,
+        model_kwargs={
+            "top_p": 0.9,
+        },
+        client=bedrock_client,
+    )
+
+    prompt = hub.pull(
+        "hwchase17/openai-functions-agent",
+        api_key=os.environ["LANGSMITH_API_KEY"],
+    )
+
+    agent = create_tool_calling_agent(model, tools, prompt)
+    agent_executor = AgentExecutor(agent=agent, tools=tools)
+
+    agent_executor.invoke({"input": "When was Amazon founded?"})
+
+    spans = span_exporter.get_finished_spans()
+
+    assert set([span.name for span in spans]) == {
+        "chat anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "chain AgentExecutor",
+        "chain RunnableSequence",
+        "chain ToolsAgentOutputParser",
+        "chain ChatPromptTemplate",
+        "chain RunnableAssign<agent_scratchpad>",
+        "chain RunnableParallel<agent_scratchpad>",
+        "chain RunnableLambda",
+        "execute_tool duckduckgo_results_json",
+    }
+
+
+@pytest.mark.vcr
+def test_agents_with_events_with_content(
+    instrument_with_content, span_exporter, log_exporter
+):
+    search = DuckDuckGoSearchResults()
+    tools = [search]
+    model = ChatBedrock(
+        model_id="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        region_name="us-west-2",
+        temperature=0.9,
+        max_tokens=2048,
+        model_kwargs={
+            "top_p": 0.9,
+        },
+    )
+
+
+    prompt = hub.pull(
+        "hwchase17/openai-functions-agent",
+        api_key=os.environ["LANGSMITH_API_KEY"],
+    )
+
+    agent = create_tool_calling_agent(model, tools, prompt)
+    agent_executor = AgentExecutor(agent=agent, tools=tools)
+
+
+    prompt = "What is AWS?"
+    response = agent_executor.invoke({"input": prompt})
+
+    spans = span_exporter.get_finished_spans()
+
+    assert set([span.name for span in spans]) == {
+        "chat anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "chain AgentExecutor",
+        "chain RunnableSequence",
+        "chain ToolsAgentOutputParser",
+        "chain ChatPromptTemplate",
+        "chain RunnableAssign<agent_scratchpad>",
+        "chain RunnableParallel<agent_scratchpad>",
+        "chain RunnableLambda",
+        "execute_tool duckduckgo_results_json",
+    }
+
+
+@pytest.mark.vcr
+def test_agents_with_events_with_no_content(
+    instrument_langchain, span_exporter
+):
+    search = DuckDuckGoSearchResults()
+    tools = [search]
+    model = ChatBedrock(
+        model_id="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        region_name="us-west-2",
+        temperature=0.9,
+        max_tokens=2048,
+        model_kwargs={
+            "top_p": 0.9,
+        },
+    )
+
+    prompt = hub.pull(
+        "hwchase17/openai-functions-agent",
+        api_key=os.environ["LANGSMITH_API_KEY"],
+    )
+
+    agent = create_tool_calling_agent(model, tools, prompt)
+    agent_executor = AgentExecutor(agent=agent, tools=tools)
+
+    agent_executor.invoke({"input": "What is AWS?"})
+
+    spans = span_exporter.get_finished_spans()
+
+    assert set([span.name for span in spans]) == {
+        "chat anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "chain AgentExecutor",
+        "chain RunnableSequence",
+        "chain ToolsAgentOutputParser",
+        "chain ChatPromptTemplate",
+        "chain RunnableAssign<agent_scratchpad>",
+        "chain RunnableParallel<agent_scratchpad>",
+        "chain RunnableLambda",
+        "execute_tool duckduckgo_results_json",
+    }

--- a/tests/tests/test_chains.py
+++ b/tests/tests/test_chains.py
@@ -1,0 +1,106 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=no-self-use
+
+import ast
+
+import boto3
+import pytest
+from langchain.chains import LLMChain, SequentialChain
+from langchain.prompts import PromptTemplate
+from langchain_aws import BedrockLLM
+
+from opentelemetry.trace import SpanKind
+
+
+def create_bedrock_llm(region="us-west-2"):
+    """Create and return a BedrockLLM instance."""
+    session = boto3.Session(region_name=region)
+    bedrock_client = session.client(service_name="bedrock-runtime", region_name=region)
+    return BedrockLLM(
+        client=bedrock_client,
+        model_id="anthropic.claude-v2",
+        model_kwargs={"max_tokens_to_sample": 500, "temperature": 0.7},
+    )
+
+
+def create_chains(llm):
+    """Create and return the sequential chain."""
+    synopsis_prompt = PromptTemplate(
+        input_variables=["title", "era"],
+        template="""You are a playwright. Given the title of play and the era it is set in, it is your job to write a synopsis for that title.
+
+    Title: {title}
+    Era: {era}
+    Playwright: This is a synopsis for the above play:""",  # noqa: E501
+    )
+
+    review_prompt = PromptTemplate(
+        input_variables=["synopsis"],
+        template="""You are a play critic from the New York Times. Given the synopsis of play, it is your job to write a review for that play.
+
+    Play Synopsis:
+    {synopsis}
+    Review from a New York Times play critic of the above play:""",  # noqa: E501
+    )
+
+    return SequentialChain(
+        chains=[
+            LLMChain(llm=llm, prompt=synopsis_prompt, output_key="synopsis", name="synopsis"),
+            LLMChain(llm=llm, prompt=review_prompt, output_key="review"),
+        ],
+        input_variables=["era", "title"],
+        output_variables=["synopsis", "review"],
+        verbose=True,
+    )
+
+
+@pytest.mark.vcr(filter_headers=["Authorization", "X-Amz-Date", "X-Amz-Security-Token"], record_mode="once")
+def test_sequential_chain(instrument_langchain, span_exporter):
+    span_exporter.clear()
+
+    # Setup and execute chain
+    input_data = {"title": "Tragedy at sunset on the beach", "era": "Victorian England"}
+    create_chains(create_bedrock_llm()).invoke(input_data)
+
+    # Get spans
+    spans = span_exporter.get_finished_spans()
+    synopsis_span = next(span for span in spans if span.name == "chain synopsis")
+    review_span = next(span for span in spans if span.name == "chain LLMChain")
+    overall_span = next(span for span in spans if span.name == "chain SequentialChain")
+
+    # Assert span names
+    assert ["chain synopsis", "chain LLMChain", "chain SequentialChain"] == [
+        span.name for span in spans if span.name.startswith("chain ")
+    ]
+
+    # Verify all spans have required attributes and kind
+    for span in [synopsis_span, review_span, overall_span]:
+        assert span.kind == SpanKind.INTERNAL
+        assert "gen_ai.prompt" in span.attributes
+        assert "gen_ai.completion" in span.attributes
+
+    # Verify synopsis span
+    synopsis_data = (
+        ast.literal_eval(synopsis_span.attributes["gen_ai.prompt"]),
+        ast.literal_eval(synopsis_span.attributes["gen_ai.completion"])
+    )
+    assert synopsis_data[0] == input_data
+    assert "synopsis" in synopsis_data[1]
+
+    # Verify review span
+    review_data = (
+        ast.literal_eval(review_span.attributes["gen_ai.prompt"]),
+        ast.literal_eval(review_span.attributes["gen_ai.completion"])
+    )
+    assert all(key in review_data[0] for key in ["title", "era", "synopsis"])
+    assert "review" in review_data[1]
+
+    # Verify overall span
+    overall_data = (
+        ast.literal_eval(overall_span.attributes["gen_ai.prompt"]),
+        ast.literal_eval(overall_span.attributes["gen_ai.completion"])
+    )
+    assert overall_data[0] == input_data
+    assert all(key in overall_data[1] for key in ["synopsis", "review"])

--- a/tests/tests/test_langgraph_agent.py
+++ b/tests/tests/test_langgraph_agent.py
@@ -1,0 +1,239 @@
+import pytest
+import os
+from langchain_aws import ChatBedrock
+import boto3
+from typing import TypedDict
+from langgraph.graph import StateGraph
+from opentelemetry import trace
+from opentelemetry.trace import INVALID_SPAN
+
+
+
+@pytest.mark.vcr(
+    filter_headers=['Authorization', 'X-Amz-Date', 'X-Amz-Security-Token'],
+    record_mode='once'
+)
+def test_langgraph_invoke(instrument_langchain, span_exporter):
+    span_exporter.clear()
+    session = boto3.Session(
+        aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+        aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
+        region_name="us-west-2"
+    )
+
+    bedrock_client = session.client(
+        service_name='bedrock-runtime',
+        region_name="us-west-2"
+    )
+
+    client = ChatBedrock(
+        model_id="anthropic.claude-3-haiku-20240307-v1:0",
+        model_kwargs={
+            "max_tokens": 1000,
+            "temperature": 0
+        },
+        client=bedrock_client
+    )
+
+    class State(TypedDict):
+        request: str
+        result: str
+
+    def calculate(state: State):
+        request = state["request"]
+        messages = [
+            {"role": "system", "content": "You are a mathematician."},
+            {"role": "user", "content": request}
+        ]
+        response = client.invoke(messages)
+        return {"result": response.content}
+
+    workflow = StateGraph(State)
+    workflow.add_node("calculate", calculate)
+    workflow.set_entry_point("calculate")
+
+    langgraph = workflow.compile()
+
+    user_request = "What's 5 + 5?"
+    response = langgraph.invoke(input={"request": user_request})["result"]
+
+    spans = span_exporter.get_finished_spans()
+    for span in spans:
+        print(f"Span: {span.name}")
+        print(f"  Attributes: {span.attributes}")
+        print("---")
+
+    expected_spans = {
+        "chain LangGraph",
+        "chain calculate",
+        "chat anthropic.claude-3-haiku-20240307-v1:0"
+    }
+
+    assert expected_spans == set([span.name for span in spans])
+
+
+    llm_span = next(span for span in spans if span.name == "chat anthropic.claude-3-haiku-20240307-v1:0")
+    calculate_task_span = next(span for span in spans if span.name == "chain calculate")
+
+    assert llm_span.parent.span_id == calculate_task_span.context.span_id
+
+    assert llm_span.attributes["gen_ai.operation.name"] == "chat"
+    assert llm_span.attributes["gen_ai.request.model"] == "anthropic.claude-3-haiku-20240307-v1:0"
+    assert llm_span.attributes["gen_ai.response.model"] == "anthropic.claude-3-haiku-20240307-v1:0"
+
+    assert "gen_ai.usage.input_tokens" in llm_span.attributes
+    assert "gen_ai.usage.output_tokens" in llm_span.attributes
+
+    assert llm_span.attributes["gen_ai.request.max_tokens"] == 1000
+    assert llm_span.attributes["gen_ai.request.temperature"] == 0
+
+    assert "gen_ai.prompt" in calculate_task_span.attributes
+    assert "gen_ai.completion" in calculate_task_span.attributes
+    assert f"What's 5 + 5?" in calculate_task_span.attributes["gen_ai.prompt"]
+
+    langgraph_span = next(span for span in spans if span.name == "chain LangGraph")
+    assert "gen_ai.prompt" in langgraph_span.attributes
+    assert "gen_ai.completion" in langgraph_span.attributes
+    assert f"What's 5 + 5?" in langgraph_span.attributes["gen_ai.prompt"]
+    assert response in langgraph_span.attributes["gen_ai.completion"]
+
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+# @pytest.mark.xfail(reason="Context propagation is not yet supported for async LangChain callbacks", strict=True)
+async def test_langgraph_ainvoke(instrument_langchain, span_exporter):
+    span_exporter.clear()
+    bedrock_client = boto3.client(
+        service_name='bedrock-runtime',
+        region_name='us-west-2'
+    )
+
+    client = ChatBedrock(
+        model_id="anthropic.claude-3-haiku-20240307-v1:0",
+        client=bedrock_client,
+        model_kwargs={
+            "max_tokens": 1000,
+            "temperature": 0
+        }
+    )
+
+    class State(TypedDict):
+        request: str
+        result: str
+
+    def calculate(state: State):
+        request = state["request"]
+        messages = [
+            {"role": "system", "content": "You are a mathematician."},
+            {"role": "user", "content": request}
+        ]
+        response = client.invoke(messages)
+        return {"result": response.content}
+
+    workflow = StateGraph(State)
+    workflow.add_node("calculate", calculate)
+    workflow.set_entry_point("calculate")
+
+    langgraph = workflow.compile()
+
+    user_request = "What's 5 + 5?"
+    await langgraph.ainvoke(input={"request": user_request})
+    spans = span_exporter.get_finished_spans()
+
+    assert set(
+        [
+            "chain LangGraph",
+            "chain calculate",
+            "chat anthropic.claude-3-haiku-20240307-v1:0"
+        ]
+    ) == set([span.name for span in spans])
+
+    llm_span = next(span for span in spans if span.name == "chat anthropic.claude-3-haiku-20240307-v1:0")
+    calculate_task_span = next(span for span in spans if span.name == "chain calculate")
+    assert llm_span.parent.span_id == calculate_task_span.context.span_id
+
+
+@pytest.mark.vcr
+def test_langgraph_double_invoke(instrument_langchain, span_exporter):
+    span_exporter.clear()
+    class DummyGraphState(TypedDict):
+        result: str
+
+    def mynode_func(state: DummyGraphState) -> DummyGraphState:
+        return state
+
+    def build_graph():
+        workflow = StateGraph(DummyGraphState)
+        workflow.add_node("mynode", mynode_func)
+        workflow.set_entry_point("mynode")
+        langgraph = workflow.compile()
+        return langgraph
+
+    graph = build_graph()
+
+    from opentelemetry import trace
+
+    assert trace.get_current_span() == INVALID_SPAN
+
+    graph.invoke({"result": "init"})
+    assert trace.get_current_span() == INVALID_SPAN
+
+    spans = span_exporter.get_finished_spans()
+    assert [
+        "chain mynode",
+        "chain LangGraph",
+    ] == [span.name for span in spans]
+
+    graph.invoke({"result": "init"})
+    assert trace.get_current_span() == INVALID_SPAN
+
+    spans = span_exporter.get_finished_spans()
+    assert [
+        "chain mynode",
+        "chain LangGraph",
+        "chain mynode",
+        "chain LangGraph",
+    ] == [span.name for span in spans]
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_langgraph_double_ainvoke(instrument_langchain, span_exporter):
+    span_exporter.clear()
+    class DummyGraphState(TypedDict):
+        result: str
+
+    def mynode_func(state: DummyGraphState) -> DummyGraphState:
+        return state
+
+    def build_graph():
+        workflow = StateGraph(DummyGraphState)
+        workflow.add_node("mynode", mynode_func)
+        workflow.set_entry_point("mynode")
+        langgraph = workflow.compile()
+        return langgraph
+
+    graph = build_graph()
+
+    assert trace.get_current_span() == INVALID_SPAN
+
+    await graph.ainvoke({"result": "init"})
+    assert trace.get_current_span() == INVALID_SPAN
+
+    spans = span_exporter.get_finished_spans()
+    assert [
+        "chain mynode",
+        "chain LangGraph",
+    ] == [span.name for span in spans]
+
+    await graph.ainvoke({"result": "init"})
+    assert trace.get_current_span() == INVALID_SPAN
+
+    spans = span_exporter.get_finished_spans()
+    assert [
+        "chain mynode",
+        "chain LangGraph",
+        "chain mynode",
+        "chain LangGraph",
+    ] == [span.name for span in spans]


### PR DESCRIPTION
Modified how we grab initial attributes in ChatModelStart and LLMStart
- separated the 1 shared function for this into two separate functions, one for each parameter we use (serialized and metadata)
- added some extra logic to getNameFromCallback to reduce duplicate code (extra if check for name value)
- modified __init__.py (bug fix, accidentally deleted the code to remove handlers upon unwrapping)
- added stop sequence to span attributes



IMPORTANT CHANGES:
chat and llm start spans are now named after the API we use ('chat ChatBedrock' or 'chat BedrockLLM' for example) rather than the model used. 
- technically against the semantic convention, probably going to change it later but at the current moment this is done to match the JS implementation